### PR TITLE
Intelli j 2021.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,24 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.0'
+    id 'org.jetbrains.intellij' version '1.3.0'
 }
 
 group 'lechuck'
-version '1.1.0'
+version '1.2.0'
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2021.2.1'
+    version = '2021.3'
 }
 
 buildSearchableOptions {
@@ -28,7 +28,7 @@ buildSearchableOptions {
 patchPluginXml {
     version = project.version
     sinceBuild = '204'
-    untilBuild = '212.*'
+    untilBuild = '213.*'
 }
 
 publishPlugin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/lechuck/intellij/TaskExecutableFileChooserDescriptor.java
+++ b/src/main/java/lechuck/intellij/TaskExecutableFileChooserDescriptor.java
@@ -8,6 +8,7 @@ public class TaskExecutableFileChooserDescriptor extends FileChooserDescriptor {
     public TaskExecutableFileChooserDescriptor() {
         super(true, false, false, false, false, false);
 
+        //noinspection DialogTitleCapitalization
         setTitle("Select task executable");
     }
 

--- a/src/main/java/lechuck/intellij/TaskSettingsEditor.java
+++ b/src/main/java/lechuck/intellij/TaskSettingsEditor.java
@@ -124,6 +124,8 @@ public class TaskSettingsEditor extends SettingsEditor<TaskRunConfiguration> {
         return panel;
     }
 
+    // TODO remove it?
+    @SuppressWarnings("unused")
     private JComponent createComponentWithMacroBrowse(TextFieldWithBrowseButton textAccessor) {
         var button = new FixedSizeButton(textAccessor);
         button.setIcon(AllIcons.Actions.ListFiles);

--- a/src/main/java/lechuck/intellij/Taskfile.java
+++ b/src/main/java/lechuck/intellij/Taskfile.java
@@ -1,14 +1,17 @@
 package lechuck.intellij;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class Taskfile {
     private Map<String, Object> tasks;
 
     public Map<String, Object> getTasks() {
-        return tasks;
+        return Collections.unmodifiableMap(tasks);
     }
 
+    // TODO remove?
+    @SuppressWarnings("unused")
     public void setTasks(Map<String, Object> tasks) {
         this.tasks = tasks;
     }

--- a/src/main/java/lechuck/intellij/util/RegexUtil.java
+++ b/src/main/java/lechuck/intellij/util/RegexUtil.java
@@ -6,10 +6,16 @@ import java.util.regex.Pattern;
 
 public class RegexUtil {
 
+    private RegexUtil() {}
+
     public static List<String> splitBySpacePreservingQuotes(String str) {
         if (str == null) {
             return List.of();
         }
+        /* TODO Character classes should be preferred over reluctant quantifiers in regular expressions
+            Found by SonarQube: Code smell Minor java:S5857
+            .+? MUST be replaced by <[^>]++>
+        */
         var matcher = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(str);
         var result = new ArrayList<String>();
         while (matcher.find()) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,10 @@
     ]]></description>
 
     <change-notes><![CDATA[
+    v1.2.0
+    <ul>
+      <li>Support for 2021.3 Jetbrains releases</li>
+    </ul>
     v1.1.0
     <ul>
       <li>add task executable path</li>


### PR DESCRIPTION
A Pull Request to support new Version 2021.3 of Jetbrains.
Tested on IntelliJ 2021.3

- changes required properties to support latest IDEA
- update plugin version to 1.2.0
- upgrade IntellijJ plugin to 1.3.0
- upgrade Gradle to 7.3
- add 3 TODO and some hints 
- refactoring a bit the Taskfile class